### PR TITLE
fix typo in pod

### DIFF
--- a/lib/FFI/CheckLib.pm
+++ b/lib/FFI/CheckLib.pm
@@ -185,7 +185,7 @@ Example:
  use FFI::Platypus;
  
  my($lib) = find_lib(
-   name => 'foo',
+   lib => 'foo',
    verify => sub {
      my($name, $libpath) = @_;
      


### PR DESCRIPTION
Hello.

fix typo in FFI::CheckLib's documentation
the `find_lib` function doesn't have a `name` key

Best Regards, Ilya Pavlov