### PR TITLE
handle more dll name variations on windows

### DIFF
--- a/corpus/windows/bin/dromornis_planei-3.0-7-0.dll
+++ b/corpus/windows/bin/dromornis_planei-3.0-7-0.dll
@@ -1,0 +1,5 @@
+dinosaur
+1.2.3
+dinosaur_init
+dinosaur_new
+dinosaur_delete

--- a/corpus/windows/bin/libmaiasaura-3-7-0.dll
+++ b/corpus/windows/bin/libmaiasaura-3-7-0.dll
@@ -1,0 +1,5 @@
+dinosaur
+1.2.3
+dinosaur_init
+dinosaur_new
+dinosaur_delete

--- a/corpus/windows/bin/libthylacaleo_carnifex-3-7___.dll
+++ b/corpus/windows/bin/libthylacaleo_carnifex-3-7___.dll
@@ -1,0 +1,5 @@
+dinosaur
+1.2.3
+dinosaur_init
+dinosaur_new
+dinosaur_delete

--- a/lib/FFI/CheckLib.pm
+++ b/lib/FFI/CheckLib.pm
@@ -99,14 +99,14 @@ elsif($os eq 'darwin')
 sub _matches
 {
   my($filename, $path) = @_;
-  my $splitchar = ($^O =~ /mswin/i) ? '-' : '.';
-#warn "++++ _matches FILENAME IS $filename";
+  my $split_re = ($os =~ /mswin/i) ? qr/\-/ : qr/\./;
+
   foreach my $regex (@$pattern)
   {
     return [
       $1,                                      # 0    capture group 1 library name
       File::Spec->catfile($path, $filename),   # 1    full path to library
-      defined $2 ? (split $splitchar, $2) : (),      # 2... capture group 2 library version
+      defined $2 ? (split $split_re, $2) : (),      # 2... capture group 2 library version
     ] if $filename =~ $regex;
   }
   return ();

--- a/lib/FFI/CheckLib.pm
+++ b/lib/FFI/CheckLib.pm
@@ -88,7 +88,8 @@ elsif($os eq 'msys')
 }
 elsif($os eq 'MSWin32')
 {
-  $pattern = [ qr{^(?:lib)?(.*?)(?:-([0-9])+)?\.dll$}i ];
+  #  handle cases like libgeos-3-7-0___.dll and libgtk-2.0-0.dll
+  $pattern = [ qr{^(?:lib)?(\w+?)(?:-([0-9-\.]+))?_*\.dll$}i ];
 }
 elsif($os eq 'darwin')
 {
@@ -98,12 +99,14 @@ elsif($os eq 'darwin')
 sub _matches
 {
   my($filename, $path) = @_;
+  my $splitchar = ($^O =~ /mswin/i) ? '-' : '.';
+#warn "++++ _matches FILENAME IS $filename";
   foreach my $regex (@$pattern)
   {
     return [
       $1,                                      # 0    capture group 1 library name
       File::Spec->catfile($path, $filename),   # 1    full path to library
-      defined $2 ? (split /\./, $2) : (),      # 2... capture group 2 library version
+      defined $2 ? (split $splitchar, $2) : (),      # 2... capture group 2 library version
     ] if $filename =~ $regex;
   }
   return ();

--- a/t/ffi_checklib__os_mswin32.t
+++ b/t/ffi_checklib__os_mswin32.t
@@ -42,6 +42,34 @@ subtest 'in sync with $ENV{PATH}' => sub {
 
 };
 
+subtest 'lib with name like libname-1-2-3.dll' => sub {
+  my($path) = find_lib( lib => 'maiasaura' );
+  ok -r $path, "path = $path is readable";
+  
+  my $path2 = find_lib( lib => 'maiasaura' );
+  is $path, $path2, 'scalar context';
+    
+};
+
+subtest 'lib with name like name-1-2-3.dll' => sub {
+  my($path) = find_lib( lib => 'dromornis_planei' );
+  ok -r $path, "path = $path is readable";
+  
+  my $path2 = find_lib( lib => 'dromornis_planei' );
+  is $path, $path2, 'scalar context';
+    
+};
+
+subtest 'lib with name like libname-1-2___.dll' => sub {
+  my($path) = find_lib( lib => 'thylacaleo_carnifex' );
+  ok -r $path, "path = $path is readable";
+  
+  my $path2 = find_lib( lib => 'thylacaleo_carnifex' );
+  is $path, $path2, 'scalar context';
+    
+};
+
+
 sub p ($)
 {
   my($path) = @_;


### PR DESCRIPTION
Added code and tests to handle more dll name variations on windows.  

The split char regex in _match might be overkill, but will not make much difference to speed.  It's a leftover from bug hunting before I found $FFI::CheckLib::os.  

Hopefully you're happy with file names from the Miocene and Pleistocene palaeofauna in addition to Mesozoic saurians...  
