### PR TITLE
use ld to find the "real" .so file from a linker script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,6 @@ jobs:
     - env: CIP_TAG=5.12
     - env: CIP_TAG=5.10
     - env: CIP_TAG=5.8
-  allow_failures:
-    - env: CIP_TAG=5.28-fedora29  CIP_ENV=EXTRA_CI=1
-    - env: CIP_TAG=5.28-centos7   CIP_ENV=EXTRA_CI=1
 
 cache:
   directories:

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Add try_linker_script option (gh#13, gh#15)
 
 0.23      2018-11-18 00:07:49 -0500
   - Handle DLLs on Windows with "dashed" version numbers (example: foo-1-2-3.dll)

--- a/README.md
+++ b/README.md
@@ -105,6 +105,20 @@ Arguments are key value pairs with these keys:
     Recursively search for libraries in any non-system paths (those provided
     via `libpath` above).
 
+- try\_linker\_script
+
+    \[version 0.24\]
+
+    Some vendors provide `.so` files that are linker scripts that point to
+    the real binary shared library.  These linker scripts can be used by gcc
+    or clang, but are not directly usable by [FFI::Platypus](https://metacpan.org/pod/FFI::Platypus) and friends.
+    On select platforms, this options will use the linker command (`ld`)
+    to attempt to resolve the real `.so` for non-binary files.  Since there
+    is extra overhead this is off by default.
+
+    An example is libyaml on RedHat based Linux distributions.  On Debian
+    these are handled with symlinks and no trickery is required.
+
 ## assert\_lib
 
     assert_lib(%args);
@@ -189,7 +203,7 @@ Not exported by default.
     my $path = FFI::CheckLib::system_path;
 
 Returns the system path as a list reference.  On some systems, this is `PATH`
-on others it might be [LD\_LIBRARY\_PATH](https://metacpan.org/pod/LD_LIBRARY_PATH) on still others it could be something
+on others it might be `LD_LIBRARY_PATH` on still others it could be something
 completely different.  So although you _may_ add items to this list, you should
 probably do some careful consideration before you do so.
 

--- a/author.yml
+++ b/author.yml
@@ -15,6 +15,7 @@ pod_spelling_system:
     - ILUX
     - Laffan
     - SLAFFAN
+    - libyaml
 
 pod_coverage:
   skip: 0

--- a/dist.ini
+++ b/dist.ini
@@ -42,3 +42,4 @@ contributor = Bakkiaraj Murugesan (bakkiaraj)
 contributor = Dan Book (grinnz, DBOOK)
 contributor = Ilya Pavlov (Ilya, ILUX)
 contributor = Shawn Laffan (SLAFFAN)
+

--- a/lib/FFI/CheckLib.pm
+++ b/lib/FFI/CheckLib.pm
@@ -555,7 +555,7 @@ sub has_symbols
  my $path = FFI::CheckLib::system_path;
 
 Returns the system path as a list reference.  On some systems, this is C<PATH>
-on others it might be L<LD_LIBRARY_PATH> on still others it could be something
+on others it might be C<LD_LIBRARY_PATH> on still others it could be something
 completely different.  So although you I<may> add items to this list, you should
 probably do some careful consideration before you do so.
 

--- a/lib/FFI/CheckLib.pm
+++ b/lib/FFI/CheckLib.pm
@@ -223,6 +223,11 @@ via C<libpath> above).
 
 my $diagnostic;
 
+sub _is_binary
+{
+  -B $_[0]
+}
+
 sub find_lib
 {
   my(%args) = @_;
@@ -285,11 +290,10 @@ sub find_lib
     if($try_ld_on_text)
     {
       @maybe = map {
-        -B $_->[1] ? $_ : do {
+        _is_binary( $_->[1] ) ? $_ : do {
           my($name, $so) = @$_;
-          warn "try to find real .so with ld";
           my $output = `/usr/bin/ld -t $so -o /dev/null -shared`;
-          $output =~ /\((.*lib.*\.so.*)\)/
+          $output =~ /\((.*?lib.*\.so.*?)\)/
             ? [$name, $1]
             : die "unable to parse ld output";
         }

--- a/t/ci.t
+++ b/t/ci.t
@@ -34,7 +34,7 @@ subtest 'yaml' => sub {
   my @yaml;
 
   is(
-    [@yaml = find_lib lib => 'yaml'],
+    [@yaml = find_lib lib => 'yaml', try_linker_script => 1],
     bag {
       item match qr/libyaml.*\.so/;
       etc;

--- a/t/ffi_checklib__os_unix.t
+++ b/t/ffi_checklib__os_unix.t
@@ -11,7 +11,14 @@ use File::Basename qw( basename );
   'corpus/unix/lib',
 );
 
-my $mock = mock_dynaloader;
+my $mock1 = mock_dynaloader;
+my $mock2 = mock 'FFI::CheckLib' => (
+  override => [
+    _is_binary => sub {
+      -f $_[0];
+    },
+  ],
+);
 
 subtest 'find_lib (good)' => sub {
   my($path) = find_lib( lib => 'foo' );

--- a/t/ffi_checklib__os_unix.t
+++ b/t/ffi_checklib__os_unix.t
@@ -12,13 +12,6 @@ use File::Basename qw( basename );
 );
 
 my $mock1 = mock_dynaloader;
-my $mock2 = mock 'FFI::CheckLib' => (
-  override => [
-    _is_binary => sub {
-      -f $_[0];
-    },
-  ],
-);
 
 subtest 'find_lib (good)' => sub {
   my($path) = find_lib( lib => 'foo' );


### PR DESCRIPTION
Possible fix for #13 