### PR TITLE
Spell Red Hat correctly

### DIFF
--- a/lib/FFI/CheckLib.pm
+++ b/lib/FFI/CheckLib.pm
@@ -228,7 +228,7 @@ On select platforms, this options will use the linker command (C<ld>)
 to attempt to resolve the real C<.so> for non-binary files.  Since there
 is extra overhead this is off by default.
 
-An example is libyaml on RedHat based Linux distributions.  On Debian
+An example is libyaml on Red Hat based Linux distributions.  On Debian
 these are handled with symlinks and no trickery is required.
 
 =back


### PR DESCRIPTION
The company name are two words.